### PR TITLE
Add device management page and fix navigation links

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -26,7 +26,7 @@
                 </div>
                 <div class="flex items-center space-x-4">
                     <a  href="dashboard.html" class="px-4 py-2 text-sm font-semibold text-blue-800 bg-blue-100 rounded-lg shadow-sm transition-all duration-300 ease-in-out">แดชบอร์ด</a>
-                    <a  href="mangement.html" class="px-4 py-2 text-sm font-medium text-gray-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-all duration-300 ease-in-out">จัดการอุปกรณ์</a>
+                    <a  href="management.html" class="px-4 py-2 text-sm font-medium text-gray-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-all duration-300 ease-in-out">จัดการอุปกรณ์</a>
                     <a  href="upload.html" class="px-4 py-2 text-sm font-medium text-gray-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-all duration-300 ease-in-out">นำเข้าข้อมูล</a>
                     <a  href="setting.html" class="px-4 py-2 text-sm font-medium text-gray-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-all duration-300 ease-in-out">ตั้งค่า</a>
                     <div class="ml-4 flex items-center">

--- a/management.html
+++ b/management.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ระบบจัดการทรัพย์สินคอมพิวเตอร์ - จัดการอุปกรณ์</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Prompt:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="css/dashboard.css">
+</head>
+<body class="bg-gradient-to-br from-blue-50 to-indigo-50">
+    <!-- Navigation -->
+    <nav class="bg-white shadow-md">
+        <div class="container mx-auto px-4">
+            <div class="flex justify-between items-center h-16">
+                <div class="flex items-center">
+                    <div class="flex-shrink-0">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-indigo-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                        </svg>
+                    </div>
+                    <div class="ml-4 text-xl font-bold text-gray-800">ระบบจัดการทรัพย์สินคอมพิวเตอร์</div>
+                </div>
+                <div class="flex items-center space-x-4">
+                    <a href="dashboard.html" class="px-4 py-2 text-sm font-medium text-gray-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-all duration-300 ease-in-out">แดชบอร์ด</a>
+                    <a href="management.html" class="px-4 py-2 text-sm font-semibold text-blue-800 bg-blue-100 rounded-lg shadow-sm transition-all duration-300 ease-in-out">จัดการอุปกรณ์</a>
+                    <a href="upload.html" class="px-4 py-2 text-sm font-medium text-gray-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-all duration-300 ease-in-out">นำเข้าข้อมูล</a>
+                    <a href="setting.html" class="px-4 py-2 text-sm font-medium text-gray-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-all duration-300 ease-in-out">ตั้งค่า</a>
+                    <div class="ml-4 flex items-center">
+                        <div class="h-8 w-8 rounded-full bg-indigo-100 flex items-center justify-center text-indigo-600 font-medium">
+                            A
+                        </div>
+                        <span class="ml-2 text-sm font-medium text-gray-700">แอดมิน</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Main Content -->
+    <div class="container mx-auto px-4 py-8">
+        <div class="flex flex-col md:flex-row justify-between items-center mb-8">
+            <div>
+                <h1 class="text-3xl font-bold text-indigo-800">จัดการอุปกรณ์</h1>
+                <p class="text-gray-600">จัดการข้อมูลอุปกรณ์ในระบบ</p>
+            </div>
+            <button class="mt-4 md:mt-0 bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 transition">
+                + เพิ่มอุปกรณ์
+            </button>
+        </div>
+
+        <!-- Device Table Placeholder -->
+        <div class="bg-white rounded-xl shadow-md overflow-hidden">
+            <table class="min-w-full divide-y divide-gray-200">
+                <thead class="bg-gray-50">
+                    <tr>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">รหัสทรัพย์สิน</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ประเภท</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">รุ่น/ยี่ห้อ</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ผู้ใช้งาน</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">สถานะ</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">การจัดการ</th>
+                    </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-200">
+                    <tr class="hover:bg-gray-50">
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">IT-PC-001</td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">Desktop</td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">Dell OptiPlex 7080</td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">สมชาย ใจดี</td>
+                        <td class="px-6 py-4 whitespace-nowrap">
+                            <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">ปกติ</span>
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                            <button class="text-indigo-600 hover:text-indigo-900 mr-2">แก้ไข</button>
+                            <button class="text-red-600 hover:text-red-900">ลบ</button>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td colspan="6" class="px-6 py-4 text-center text-sm text-gray-500">กำลังพัฒนาฟีเจอร์...</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</body>
+</html>

--- a/upload.html
+++ b/upload.html
@@ -91,7 +91,7 @@
                 </div>
                 <div class="flex items-center space-x-4">
                     <a  href="dashboard.html" class="px-4 py-2 text-sm font-medium text-gray-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-all duration-300 ease-in-out">แดชบอร์ด</a>
-                    <a  href="mangement.html" class="px-4 py-2 text-sm font-medium text-gray-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-all duration-300 ease-in-out">จัดการอุปกรณ์</a>
+                    <a  href="management.html" class="px-4 py-2 text-sm font-medium text-gray-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-all duration-300 ease-in-out">จัดการอุปกรณ์</a>
                     <a  href="upload.html" class="px-4 py-2 text-sm font-semibold text-blue-800 bg-blue-100 rounded-lg shadow-sm transition-all duration-300 ease-in-out">นำเข้าข้อมูล</a>
                     <a  href="setting.html" class="px-4 py-2 text-sm font-medium text-gray-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-all duration-300 ease-in-out">ตั้งค่า</a>
                     <div class="ml-4 flex items-center">


### PR DESCRIPTION
## Summary
- add `management.html` with navigation highlighting device management and placeholder table
- fix navigation links in existing pages to use `management.html`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c68f9a148326ae0477acc6f98597