### PR TITLE
refactor: centralize navigation markup

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -9,36 +9,12 @@
     <link rel="stylesheet" href="css/dashboard.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="js/dashboard.js" defer></script>
+    <script src="js/nav.js" defer></script>
  
 </head>
 <body class="bg-gradient-to-br from-blue-50 to-indigo-50">
         <!-- Navigation -->
-    <nav class="bg-white shadow-md">
-        <div class="container mx-auto px-4">
-            <div class="flex justify-between items-center h-16">
-                <div class="flex items-center">
-                    <div class="flex-shrink-0">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-indigo-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-                        </svg>
-                    </div>
-                    <div class="ml-4 text-xl font-bold text-gray-800">ระบบจัดการทรัพย์สินคอมพิวเตอร์</div>
-                </div>
-                <div class="flex items-center space-x-4">
-                    <a  href="dashboard.html" class="px-4 py-2 text-sm font-semibold text-blue-800 bg-blue-100 rounded-lg shadow-sm transition-all duration-300 ease-in-out">แดชบอร์ด</a>
-                    <a  href="management.html" class="px-4 py-2 text-sm font-medium text-gray-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-all duration-300 ease-in-out">จัดการอุปกรณ์</a>
-                    <a  href="upload.html" class="px-4 py-2 text-sm font-medium text-gray-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-all duration-300 ease-in-out">นำเข้าข้อมูล</a>
-                    <a  href="setting.html" class="px-4 py-2 text-sm font-medium text-gray-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-all duration-300 ease-in-out">ตั้งค่า</a>
-                    <div class="ml-4 flex items-center">
-                        <div class="h-8 w-8 rounded-full bg-indigo-100 flex items-center justify-center text-indigo-600 font-medium">
-                            A
-                        </div>
-                        <span class="ml-2 text-sm font-medium text-gray-700">แอดมิน</span>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </nav>
+    <div id="navbar"></div>
 
     
     <div class="container mx-auto px-4 py-8">

--- a/js/nav.js
+++ b/js/nav.js
@@ -1,0 +1,16 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const container = document.getElementById('navbar');
+    if (!container) return;
+    fetch('nav.html')
+        .then(res => res.text())
+        .then(html => {
+            container.innerHTML = html;
+            const page = window.location.pathname.split('/').pop().replace('.html', '');
+            const active = container.querySelector(`a[data-page="${page}"]`);
+            if (active) {
+                active.classList.remove('font-medium', 'text-gray-600', 'hover:text-blue-700', 'hover:bg-blue-50');
+                active.classList.add('font-semibold', 'text-blue-800', 'bg-blue-100', 'shadow-sm');
+            }
+        })
+        .catch(err => console.error('Failed to load navigation', err));
+});

--- a/management.html
+++ b/management.html
@@ -7,35 +7,11 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Prompt:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/dashboard.css">
+    <script src="js/nav.js" defer></script>
 </head>
 <body class="bg-gradient-to-br from-blue-50 to-indigo-50">
     <!-- Navigation -->
-    <nav class="bg-white shadow-md">
-        <div class="container mx-auto px-4">
-            <div class="flex justify-between items-center h-16">
-                <div class="flex items-center">
-                    <div class="flex-shrink-0">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-indigo-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-                        </svg>
-                    </div>
-                    <div class="ml-4 text-xl font-bold text-gray-800">ระบบจัดการทรัพย์สินคอมพิวเตอร์</div>
-                </div>
-                <div class="flex items-center space-x-4">
-                    <a href="dashboard.html" class="px-4 py-2 text-sm font-medium text-gray-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-all duration-300 ease-in-out">แดชบอร์ด</a>
-                    <a href="management.html" class="px-4 py-2 text-sm font-semibold text-blue-800 bg-blue-100 rounded-lg shadow-sm transition-all duration-300 ease-in-out">จัดการอุปกรณ์</a>
-                    <a href="upload.html" class="px-4 py-2 text-sm font-medium text-gray-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-all duration-300 ease-in-out">นำเข้าข้อมูล</a>
-                    <a href="setting.html" class="px-4 py-2 text-sm font-medium text-gray-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-all duration-300 ease-in-out">ตั้งค่า</a>
-                    <div class="ml-4 flex items-center">
-                        <div class="h-8 w-8 rounded-full bg-indigo-100 flex items-center justify-center text-indigo-600 font-medium">
-                            A
-                        </div>
-                        <span class="ml-2 text-sm font-medium text-gray-700">แอดมิน</span>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </nav>
+    <div id="navbar"></div>
 
     <!-- Main Content -->
     <div class="container mx-auto px-4 py-8">

--- a/nav.html
+++ b/nav.html
@@ -1,0 +1,24 @@
+<nav class="bg-white shadow-md">
+    <div class="container mx-auto px-4">
+        <div class="flex justify-between items-center h-16">
+            <div class="flex items-center">
+                <div class="flex-shrink-0">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-indigo-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                    </svg>
+                </div>
+                <div class="ml-4 text-xl font-bold text-gray-800">ระบบจัดการทรัพย์สินคอมพิวเตอร์</div>
+            </div>
+            <div class="flex items-center space-x-4">
+                <a href="dashboard.html" data-page="dashboard" class="px-4 py-2 text-sm font-medium text-gray-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-all duration-300 ease-in-out">แดชบอร์ด</a>
+                <a href="management.html" data-page="management" class="px-4 py-2 text-sm font-medium text-gray-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-all duration-300 ease-in-out">จัดการอุปกรณ์</a>
+                <a href="upload.html" data-page="upload" class="px-4 py-2 text-sm font-medium text-gray-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-all duration-300 ease-in-out">นำเข้าข้อมูล</a>
+                <a href="setting.html" data-page="setting" class="px-4 py-2 text-sm font-medium text-gray-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-all duration-300 ease-in-out">ตั้งค่า</a>
+                <div class="ml-4 flex items-center">
+                    <div class="h-8 w-8 rounded-full bg-indigo-100 flex items-center justify-center text-indigo-600 font-medium">A</div>
+                    <span class="ml-2 text-sm font-medium text-gray-700">แอดมิน</span>
+                </div>
+            </div>
+        </div>
+    </div>
+</nav>

--- a/test.html
+++ b/test.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="css/dashboard.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="js/dashboard.js" defer></script>
+    <script src="js/nav.js" defer></script>
 
     <style>
         body {
@@ -88,6 +89,7 @@
     </style>
 </head>
 <body>
+<div id="navbar"></div>
 <div class="bg-gray-50 p-6 rounded-lg mb-6">
                                 <h5 class="text-lg font-semibold text-gray-700 mb-4">สเปคคอมพิวเตอร์</h5>
                                 <div class="space-y-4">

--- a/upload.html
+++ b/upload.html
@@ -8,6 +8,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Prompt:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
+    <script src="js/nav.js" defer></script>
     <style>
         body {
             font-family: 'Prompt', sans-serif;
@@ -78,32 +79,7 @@
 </head>
 <body class="bg-gradient-to-br from-blue-50 to-indigo-50">
     <!-- Navigation -->
-    <nav class="bg-white shadow-md">
-        <div class="container mx-auto px-4">
-            <div class="flex justify-between items-center h-16">
-                <div class="flex items-center">
-                    <div class="flex-shrink-0">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-indigo-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-                        </svg>
-                    </div>
-                    <div class="ml-4 text-xl font-bold text-gray-800">ระบบจัดการทรัพย์สินคอมพิวเตอร์</div>
-                </div>
-                <div class="flex items-center space-x-4">
-                    <a  href="dashboard.html" class="px-4 py-2 text-sm font-medium text-gray-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-all duration-300 ease-in-out">แดชบอร์ด</a>
-                    <a  href="management.html" class="px-4 py-2 text-sm font-medium text-gray-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-all duration-300 ease-in-out">จัดการอุปกรณ์</a>
-                    <a  href="upload.html" class="px-4 py-2 text-sm font-semibold text-blue-800 bg-blue-100 rounded-lg shadow-sm transition-all duration-300 ease-in-out">นำเข้าข้อมูล</a>
-                    <a  href="setting.html" class="px-4 py-2 text-sm font-medium text-gray-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-all duration-300 ease-in-out">ตั้งค่า</a>
-                    <div class="ml-4 flex items-center">
-                        <div class="h-8 w-8 rounded-full bg-indigo-100 flex items-center justify-center text-indigo-600 font-medium">
-                            A
-                        </div>
-                        <span class="ml-2 text-sm font-medium text-gray-700">แอดมิน</span>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </nav>
+    <div id="navbar"></div>
 
     <!-- Main Content -->
     <div class="container mx-auto px-4 py-8">


### PR DESCRIPTION
## Summary
- Share a single navigation snippet across pages
- Highlight active nav link with text-blue-800 and bg-blue-100 classes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6dbf6a2f48326969d22c9157b2c5c